### PR TITLE
Clone from latest tag

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,9 @@ module.exports = {
         'browser': true,
         'node': true
     },
+    'globals': {
+        'Promise': true
+    },
     'extends': 'eslint:recommended',
     'rules': {
         'brace-style':                 ['error', '1tbs', { 'allowSingleLine': true }],


### PR DESCRIPTION
## Notes

Buble is not running properly, so by the time it gets to Uglify it fails (because Uglify only works with ES5). Removing Uglify allows the build to "succeed" but it doesn't actually work when you move the files and load it in NW.js.


## Missing devDependencies:

* webpack
* webpack-cli
* webpack-merge
* vue-loader
* friendly-errors-webpack-plugin
* uglifyjs-webpack-plugin
* buble
* buble-loader
* vue-template-compiler
* css-loader
* postcss-loader
* stylus-loader
* style-resources-loader
* @vue/ui
* d3
* url-loader
* vue-router
* vue-virtual-scroller
* vuex
* stylus
* file-loader


## Current workarounds

* * *

`vue-devtools/packages/shell-chrome/webpackconfig.js`

Change this line:
```js
const { createConfig } = require('@vue-devtools/build-tools')
```
to
```js
const { createConfig } = require('../build-tools')
```

* * *

`vue-devtools/packages/build-tools/src/createConfig.js`

Change the Buble transforms to have:
```js
asyncAwait: false,
```

* * *

`vue-devtools/packages/build-tools/src/createConfig.js`

Change this
```js
require.resolve('@vue-devtools/app-frontend/src/style/imports.styl')
```
to
```js
require.resolve('../app-frontend/src/style/imports.styl')
```

* * *

`vue-devtools/packages/build-tools/src/createConfig.js`
remove this
```js
mangle: {
  safari10: false
}
```